### PR TITLE
Ignore development-installation files (.egg-info) with gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+*.py[cod]
+*.egg
+build
+htmlcov
+
+*.egg-info
+
+**/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,4 @@
 .DS_Store
-.idea
-*.log
-tmp/
-
 *.py[cod]
-*.egg
-build
-htmlcov
-
 *.egg-info
-
 **/__pycache__


### PR DESCRIPTION
installing the package in development mode (`pip install -e .`) can create a `mamba_lens.egg-info` directory in the top-level. That should not be committed.